### PR TITLE
Enables GIT_REPOs with other protocols (`http` instead of `https`)

### DIFF
--- a/bin/create-git-url.sh
+++ b/bin/create-git-url.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+create_git_url () {
+    repo=$1
+    credentials=$2
+    protocol="https"
+
+	# The protocol is optional. But when one was provided we have to respect it.
+	# Otherwise we will fall back to https.
+	if [[ ${repo} =~ ^https?:// ]]; then
+		protocol=${repo%%:\/\/*}
+		repo=${repo/#http*:\/\//}
+	fi
+
+    if [ ! -z ${credentials} ]; then
+	    GIT_URL=${protocol}://${credentials}@${repo}
+	else
+	    echo "Assuming public repository, GIT_CREDENTIALS is empty"
+	    GIT_URL=${protocol}://${repo}
+	fi
+
+}

--- a/bin/create-git-url.sh
+++ b/bin/create-git-url.sh
@@ -5,18 +5,18 @@ create_git_url () {
     credentials=$2
     protocol="https"
 
-	# The protocol is optional. But when one was provided we have to respect it.
-	# Otherwise we will fall back to https.
-	if [[ ${repo} =~ ^https?:// ]]; then
-		protocol=${repo%%:\/\/*}
-		repo=${repo/#http*:\/\//}
-	fi
+    # The protocol is optional. But when one was provided we have to respect it.
+    # Otherwise we will fall back to https.
+    if [[ ${repo} =~ ^https?:// ]]; then
+        protocol=${repo%%:\/\/*}
+        repo=${repo/#http*:\/\//}
+    fi
 
     if [ ! -z ${credentials} ]; then
-	    GIT_URL=${protocol}://${credentials}@${repo}
-	else
-	    echo "Assuming public repository, GIT_CREDENTIALS is empty"
-	    GIT_URL=${protocol}://${repo}
-	fi
+        GIT_URL=${protocol}://${credentials}@${repo}
+    else
+        echo "Assuming public repository, GIT_CREDENTIALS is empty"
+        GIT_URL=${protocol}://${repo}
+    fi
 
 }

--- a/bin/docker-start.sh
+++ b/bin/docker-start.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+. create-git-url.sh
+
 runtimeEnv=$(uname)
 
 echo "Running as $(whoami)."
@@ -27,22 +29,15 @@ if [ ! -z "$GIT_REPO" ]; then
         exit 1
     fi
 
+	# this will create and set the GIT_URL variable
+	create_git_url $GIT_REPO $GIT_CREDENTIALS
+
     if [ -z "$GIT_BRANCH" ]; then
         echo "Checking out branch 'master'..."
-        if [ ! -z "$GIT_CREDENTIALS" ]; then
-            git clone https://${GIT_CREDENTIALS}@${GIT_REPO} .
-        else
-            echo "Assuming public repository, GIT_CREDENTIALS is empty"
-            git clone https://${GIT_REPO} .
-        fi
+        git clone ${GIT_URL} .
     else
         echo "Checking out branch '$GIT_BRANCH'..."
-        if [ ! -z "$GIT_CREDENTIALS" ]; then
-            git clone https://${GIT_CREDENTIALS}@${GIT_REPO} --branch ${GIT_BRANCH} .
-        else
-            echo "Assuming public repository, GIT_CREDENTIALS is empty"
-            git clone https://${GIT_REPO} --branch ${GIT_BRANCH} .
-        fi
+        git clone ${GIT_URL} --branch ${GIT_BRANCH} .
     fi
 
     if [ ! -z "$GIT_REVISION" ]; then

--- a/run-bash-tests.sh
+++ b/run-bash-tests.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+echo Running bash tests
+
+pushd test
+for f in *.sh
+do
+	echo "Running $f"
+	./${f}
+done
+popd

--- a/run-unit-tests.sh
+++ b/run-unit-tests.sh
@@ -39,3 +39,7 @@ fi
 kill -2 $TEMP_API_PID
 
 rm -rf $TMP_TEST
+
+####
+
+./run-bash-tests.sh

--- a/test/create-git-url-test.sh
+++ b/test/create-git-url-test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# import function under test
+. ../bin/create-git-url.sh
+
+# inputs
+URL_HTTP="http://bla.com"
+URL_HTTPS="https://bla.com"
+URL_NAKED="bla.com"
+
+CREDENTIALS="user:password"
+
+# expected results
+URL_HTTP_FULL="http://user:password@bla.com"
+URL_HTTPS_FULL="https://user:password@bla.com"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+test_git_url () {
+	expected=$1
+	create_git_url $2 $3
+
+	result=${GIT_URL}
+
+	if [ "$expected" = "$result" ]; then
+		echo -e "${GREEN}SUCCESS${NC}"
+	else
+		echo -e "${RED}FAILURE${NC}"
+		echo "expected $expected but got $result"
+	fi
+}
+
+test_git_url ${URL_HTTP} ${URL_HTTP}
+test_git_url ${URL_HTTPS} ${URL_HTTPS}
+test_git_url ${URL_HTTPS} ${URL_NAKED}
+
+test_git_url ${URL_HTTP_FULL} ${URL_HTTP} ${CREDENTIALS}
+test_git_url ${URL_HTTPS_FULL} ${URL_HTTPS} ${CREDENTIALS}
+test_git_url ${URL_HTTPS_FULL} ${URL_NAKED} ${CREDENTIALS}
+


### PR DESCRIPTION
I am talking about the git url which is used to load the static config. I changed the creation of said url in a way that you now have to option to define it with an optional prefixed protocol. 
It is now possible to define `GIT_REPO` as:

* bla.com/path/to/repo.git
* https://bla.com/path/to/repo.git
* http://bla.com/path/to/repo.git

The protocol is going to be respected or respectively added to the URL.

I also created a bash script for tests which is run whenever the unit tests are run. But I just learned that `run-unit-tests.sh` is deprecated, so you probably want to change the way the script is executed. I was unable to find the right place.
